### PR TITLE
Add prop to deselect via option

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -142,6 +142,15 @@
       },
 
       /**
+       * Can the user deselect an option by clicking it.
+       * @type {Boolean}
+       */
+      deselectByOption: {
+        type: Boolean,
+        default: false
+      },
+
+      /**
        * Enable/disable filtering the options.
        * @type {Boolean}
        */
@@ -582,7 +591,9 @@
       },
 
       /**
-       * Select a given option.
+       * Select or deselect a given option.
+       *
+       * Allow deselect if clearable or if not the only selected option
        * @param  {Object|String} option
        * @return {void}
        */
@@ -596,6 +607,8 @@
             option = this.selectedValue.concat(option)
           }
           this.updateValue(option);
+        } else if (this.deselectByOption && (this.clearable || this.multiple && this.val.length > 1)) {
+          this.deselect(option)
         }
 
         this.onAfterSelect(option)


### PR DESCRIPTION
Also tried unit testing the deselect behavior but was unable to query the option for some reason (`Select.find('option')` returned nothing 🤔)

```js
// Select.spec.js
it("can deselect an option by clicking it", () => {
  const Select = shallowMount(VueSelect, {
    propsData: {
      clearable: true,
      deselectByOption: true,
      options: ["foo", "bar"]
    }
  });
  Select.vm.$data._value = "foo";
  Select.vm.toggleDropdown({ target: Select.vm.$refs.search });
  Select.find('option').trigger('click');
  expect(Select.vm.selectedValue).toEqual([]);
});
```